### PR TITLE
Create Discord-native scheduled events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.sqlite
 *.sqlite3
 images/generated_graphs/*.png
+.idea/

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,7 @@
 [Tokens]
-discord_bot = 
-sepush = 
+discord_bot =
+sepush =
+
+[Server]
+server_id =
+scheduling_vc_id =

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -15,6 +15,9 @@ TODO: Look at command groups rather than the underscores as I have them now
 TODO: Need a command to completely remove groups from the db
 """
 
+config = configparser.ConfigParser()
+config.read("config.ini")
+
 description = '''A bot to help you schedule games.
 
 For help, type ?help'''
@@ -23,6 +26,7 @@ intents = discord.Intents.default()
 intents.reactions = True
 intents.message_content = True
 intents.members = True
+intents.guild_scheduled_events = True
 
 help_command = commands.DefaultHelpCommand(no_category = 'Commands', show_parameter_descriptions=False)
 bot = commands.Bot(command_prefix='?',description=description, intents=intents, help_command = help_command)
@@ -52,7 +56,7 @@ async def schedule(ctx, group: str, time=None):
         return
 
     # If there's just one parameter
-    if time is None or helpers.isTimeFormat(time) == False:
+    if time is None or helpers.is_time_format(time) == False:
         hours_dict = helpers.schedule_group(group)
         result = helpers.stringify_can_join(hours_dict)
         if result == "[]":
@@ -61,21 +65,41 @@ async def schedule(ctx, group: str, time=None):
             msg = "You can schedule {} at these times today: \n".format(group)
             msg += result
 
-    if helpers.isTimeFormat(time):
+    if helpers.is_time_format(time):
         uids = db_helpers.get_group_members(db_helpers.get_group_id(group))
         members = [db_helpers.get_name("users", i) for i in uids]
         if len(members) == 0:
-            msg = "Hey there!"
+            msg_intro = "Hey there!"
         else:
             if str(ctx.author.id) in members:
                     members.remove(str(ctx.author.id))
             member_list = ", ".join(f"<@{member}>" for member in members)
-            msg = "Hey there {}!".format(member_list)
-        msg = msg + " {} would like to schedule {} for {} today! RSVP below.".format(ctx.message.author.mention, group, time)
+            msg_intro = f"Hey there {member_list}!"
 
-        message_sent = await ctx.send(msg)
-        await message_sent.add_reaction('\N{THUMBS UP SIGN}')
-        await message_sent.add_reaction('\N{THUMBS DOWN SIGN}')
+        guild = bot.get_guild(int(config["Server"]["server_id"]))
+
+        # Would be nice to stash this, but the call volume should be low enough for now
+        channel = await bot.fetch_channel(int(config["Server"]["scheduling_vc_id"]))
+
+        event: discord.ScheduledEvent = await guild.create_scheduled_event(
+            name=f"{group}",
+            channel=channel,
+            start_time=helpers.to_tz_aware_datetime(time),
+            privacy_level=discord.PrivacyLevel.guild_only,
+            entity_type=discord.EntityType.voice
+        )
+
+        try:
+            invite: discord.Invite = await channel.create_invite(temporary=True)
+            invite_link = f"{invite}?event={event.id}"
+        except:
+            invite_link = ("The bot failed to create an invite link. You'll need to open the event manually to mark "
+                           "yourself interested")
+
+        msg = f"{msg_intro} {ctx.message.author.mention} would like to schedule {group} for {time} today!\n{invite_link}"
+
+        await ctx.send(msg)
+
         return
     elif time != None:
         msg = "I couldn't understand your time format, but y" + msg[1:]
@@ -115,8 +139,5 @@ async def timetable(ctx, *, group: str ="ALL"):
 async def on_command_error(ctx, error):
     await ctx.send(f"An error occured: {error}")
 
-
 if __name__ == "__main__":
-    config = configparser.ConfigParser()
-    config.read("config.ini")
     bot.run(config["Tokens"]["discord_bot"], root_logger=True)

--- a/helpers.py
+++ b/helpers.py
@@ -5,7 +5,7 @@ import loadshedding_helpers
 import os
 import matplotlib.pyplot as plt
 
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 import time
 import pathlib
 
@@ -204,7 +204,7 @@ def generate_graph(group, uid2nick):
 
     return plot_name
 
-def isTimeFormat(input):
+def is_time_format(input):
     if input is None:
         return False
     try:
@@ -212,6 +212,24 @@ def isTimeFormat(input):
         return True
     except ValueError:
         return False
+
+def to_tz_aware_datetime(input):
+    if is_time_format(input):
+        # Everyone lives in UTC+2, so this will never have to be updated.
+        tzinfo = timezone(timedelta(hours=2))
+        now = datetime.now()
+        scheduled_time = datetime.strptime(input, '%H:%M').replace(tzinfo=tzinfo).time()
+        return datetime(
+            now.year,
+            now.month,
+            now.day,
+            scheduled_time.hour,
+            scheduled_time.minute,
+            tzinfo=scheduled_time.tzinfo
+        ).astimezone()
+    else:
+        raise "Scheduled time string can't be empty"
+
 
 if __name__ == "__main__":
     # print(stringify_can_join(schedule_group("mw2")))


### PR DESCRIPTION
Discord now supports scheduled events in the app itself, so we can use those instead of relying on reactions to RSVP. This commit also adds new config keys to set the server and voice channel that games should be scheduled in. If the bot's to be expanded to supporting multiple servers simultaneously, that'd need to be stored in the DB, rather than static config, but it works fine for now.